### PR TITLE
Calls load() explicitly to load sites from disk.

### DIFF
--- a/src/main/java/com/srcclr/jenkins/installer/SrcclrUpdateSitePlugin.java
+++ b/src/main/java/com/srcclr/jenkins/installer/SrcclrUpdateSitePlugin.java
@@ -43,23 +43,27 @@ public class SrcclrUpdateSitePlugin extends Plugin {
     }
     UpdateCenter updateCenter = jenkins.getUpdateCenter();
 
-    // this and the exists boolean check below is fix for PDVLP-293
+    // this and existingSrcclrUpdateSite check below is fix for PDVLP-293
     updateCenter.load();
 
     List<UpdateSite> sites = Lists.newArrayList(updateCenter.getSites());
 
-    boolean exists = false;
+    UpdateSite existingSrcclrUpdateSite = null;
 
     for (UpdateSite updateSite : sites) {
       if (updateSite instanceof SrcclrUpdateSite) {
-        exists = true;
+        existingSrcclrUpdateSite = updateSite;
+        break;
       }
     }
 
-    if (!exists) {
-      sites.add(new SrcclrUpdateSite());
-      updateCenter.getSites().replaceBy(sites);
+    if (existingSrcclrUpdateSite != null) {
+      sites.remove(existingSrcclrUpdateSite);
     }
+
+    sites.add(new SrcclrUpdateSite());
+    updateCenter.getSites().replaceBy(sites);
+
   }
 
 }

--- a/src/main/java/com/srcclr/jenkins/installer/SrcclrUpdateSitePlugin.java
+++ b/src/main/java/com/srcclr/jenkins/installer/SrcclrUpdateSitePlugin.java
@@ -42,11 +42,24 @@ public class SrcclrUpdateSitePlugin extends Plugin {
       throw new RuntimeException("Jenkins not found");
     }
     UpdateCenter updateCenter = jenkins.getUpdateCenter();
-    updateCenter.load();
-    List<UpdateSite> sites = Lists.newArrayList(updateCenter.getSites());
-    sites.add(new SrcclrUpdateSite());
 
-    updateCenter.getSites().replaceBy(sites);
+    // this and the exists boolean check below is fix for PDVLP-293
+    updateCenter.load();
+
+    List<UpdateSite> sites = Lists.newArrayList(updateCenter.getSites());
+
+    boolean exists = false;
+
+    for (UpdateSite updateSite : sites) {
+      if (updateSite instanceof SrcclrUpdateSite) {
+        exists = true;
+      }
+    }
+
+    if (!exists) {
+      sites.add(new SrcclrUpdateSite());
+      updateCenter.getSites().replaceBy(sites);
+    }
   }
 
 }

--- a/src/main/java/com/srcclr/jenkins/installer/SrcclrUpdateSitePlugin.java
+++ b/src/main/java/com/srcclr/jenkins/installer/SrcclrUpdateSitePlugin.java
@@ -42,6 +42,7 @@ public class SrcclrUpdateSitePlugin extends Plugin {
       throw new RuntimeException("Jenkins not found");
     }
     UpdateCenter updateCenter = jenkins.getUpdateCenter();
+    updateCenter.load();
     List<UpdateSite> sites = Lists.newArrayList(updateCenter.getSites());
     sites.add(new SrcclrUpdateSite());
 


### PR DESCRIPTION
Refer to https://jira.ksp.ops2.srcclr.io/browse/PDVLP-293 for details. Basically, the installer plugin replaces the list of update sites with our own update site when it should just add itself to the list.

I tried to reproduce the bug on several versions of Jenkins but I could only reproduce it on a container running Jenkins 1.651.3 (the version which the customer is running).

After much debugging, I realized that `updateCenter.getSites()` is returning an empty list in Jenkins 1.651.3. Looking at their source code, they have a `load()` method that loads update sites from the default config file. Although I am not sure calling `load()` is the best solution, it is a solution.

It now works on the container running Jenkins 1.651.3 and does not seem to break anything that was already working in other versions of Jenkins.